### PR TITLE
mongo driver v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 
 Initialises mongodb connections (per database), and manages indexes.
 
-This module doesn't explicitly depend on mongodb, but requires it to be passed in on the options. This means you're free to use your favourite version. Tested with 1.4.7 and up.
+This module doesn't explicitly depend on mongodb, but requires it to be passed in on the options. This means you're free to use your "favourite" version.
+
+Unfortunately thanks to the breaking changes introduced in the 2.x driver then hapi-mongodb-init@3.x.x will work with mongodb@2.x.x.
 
 To initialise:
 
@@ -33,6 +35,10 @@ server.plugin.register({
 });
 
 ```
+
+Other options:
+
+- `failOnIndexes` (true | false): optionally ignore any errors while managing indexes
 
 To use inside a module:
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -3,14 +3,10 @@ var indexes = require("./indexes");
 var db = {};
 var options = {
     server: {
-        auto_reconnect: true,
-        poolSize: 10,
-        socketOptions: {
-            keepAlive: 1
-        }
+        poolSize: 10
     },
     replSet: {
-        strategy: "ping"
+        connectWithNoPrimary: true
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-mongodb-init",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "initialises mongo db connections for hapi",
   "main": "index.js",
   "scripts": {
@@ -30,5 +30,8 @@
   "dependencies": {
     "async": "^1.4.0",
     "underscore": "^1.8.3"
+  },
+  "peerDependencies": {
+    "mongodb": "^2.0.0"
   }
 }

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -77,14 +77,10 @@ describe('db-init tests', function(){
           }, function(err){
             connectOptions.should.eql({
               server: {
-                  auto_reconnect: true,
-                  poolSize: 10,
-                  socketOptions: {
-                      keepAlive: 1
-                  }
+                  poolSize: 10
               },
               replSet: {
-                  strategy: "ping"
+                  connectWithNoPrimary: true
               }
             })
             done(err);


### PR DESCRIPTION
Removed:
- `strategy` is always ping (when using readPreference nearest)
- `autoReconnect` is set to true by default (ignore what the docs say)
- `keepAlive` is largely bollocks

Added:
- `connectWithNoPrimary` should be true, otherwise the driver won't even execute reads without a primary

#typicalmongobullshit